### PR TITLE
Fixed Date of Start default value in Customer Prepare such that date …

### DIFF
--- a/src/store/Payload/index.ts
+++ b/src/store/Payload/index.ts
@@ -1,3 +1,9 @@
+// Function to get the days in the month of the year
+// by passing the month (1-12) and year to the function daysInMonth.
+function daysInMonth(month: number, year: number) {
+    return new Date(year, month, 0).getDate();
+}
+
 // Define an initial payload with default values for form data
 export let payload = {
     city_id: "14",
@@ -92,8 +98,26 @@ export let CustomerMovePayload = {
     arrival_date: ""
 };
 
-var currentDate = new Date();
+var currentFullDate = new Date();
+var month: any = currentFullDate.getMonth()+1;
+var year = currentFullDate.getFullYear();
+var dateExpected: any = currentFullDate.getDate() + 14;
 
+if(dateExpected > daysInMonth(month, year)){
+    dateExpected -= daysInMonth(month, year);
+    month += 1;
+    if(month == 13){
+        month = 1;
+    }
+    
+    if(month < 10){
+        month = `0${month}`
+    }
+    
+    if(dateExpected < 10){
+        dateExpected = `0${dateExpected}`
+    }
+}
 // Define an empty payload with default values for form data
 export let CustomerMovePayload1 = {
     origin_country_id: '',
@@ -108,7 +132,7 @@ export let CustomerMovePayload1 = {
     load_quantity: '',
     broad_category_id: '',
     product_type_id: '',
-    dispatch_date: `${currentDate.getFullYear()}-${currentDate.getMonth()+1}-${currentDate.getDate()}`,
+    dispatch_date: `${year}-${currentFullDate.getMonth()+1}-${currentFullDate.getDate()}`,
     arrival_date: ''
 }
 
@@ -149,5 +173,5 @@ export let CustomerPrepare={
     temp_min: '',
     temp_max: '',
     temp_unit_id: 1,
-    date_of_start:`${currentDate.getFullYear()}-${currentDate.getMonth()+1}-${currentDate.getDate()+14}`
+    date_of_start:`${year}-${month}-${dateExpected}`
   }


### PR DESCRIPTION
…is always shown in the textbox, therefore fixing the warning 'Provided date is not in yyyy-MM-DD format'